### PR TITLE
fix: get provider from `window.exodus.ethereum`

### DIFF
--- a/packages/rainbowkit/src/wallets/walletConnectors/exodusWallet/exodusWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/exodusWallet/exodusWallet.ts
@@ -1,4 +1,5 @@
 /* eslint-disable sort-keys-fix/sort-keys-fix */
+import type { Ethereum } from '@wagmi/core';
 import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { Wallet } from '../../Wallet';
@@ -7,6 +8,12 @@ export interface ExodusOptions {
   chains: Chain[];
   shimDisconnect?: boolean;
 }
+
+interface ExodusProvider {
+  ethereum: Ethereum;
+}
+
+type ExodusWindow = Window & { exodus?: ExodusProvider };
 
 export const exodusWallet = ({
   chains,
@@ -17,7 +24,8 @@ export const exodusWallet = ({
   iconUrl: async () => (await import('./exodusWallet.svg')).default,
   iconBackground: '#fff',
   installed:
-    typeof window !== 'undefined' && window.ethereum?.isExodus === true,
+    typeof window !== 'undefined' &&
+    (window as ExodusWindow)?.exodus?.ethereum !== undefined,
   downloadUrls: {
     browserExtension:
       'https://chrome.google.com/webstore/detail/exodus/aholpfdialjgjfhomihkjbmgjidlcdno',
@@ -26,7 +34,13 @@ export const exodusWallet = ({
     return {
       connector: new InjectedConnector({
         chains,
-        options: { shimDisconnect },
+        options: {
+          shimDisconnect,
+          getProvider: () =>
+            typeof window !== 'undefined'
+              ? (window as ExodusWindow)?.exodus?.ethereum
+              : undefined,
+        },
       }),
     };
   },


### PR DESCRIPTION
Fixes the exodus ethereum provider path in Window object so the sync injection actually fixes the race condition.

**Tested:**

1. Apply the patch:
```
Subject: [PATCH] fix: get provider from `window.exodus.ethereum`
---
Index: examples/with-next/pages/_app.tsx
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/examples/with-next/pages/_app.tsx b/examples/with-next/pages/_app.tsx
--- a/examples/with-next/pages/_app.tsx	(revision 8186995b15af3912083900cf5abffff044adfae4)
+++ b/examples/with-next/pages/_app.tsx	(date 1681993434230)
@@ -10,6 +10,7 @@
   argentWallet,
   trustWallet,
   ledgerWallet,
+  exodusWallet,
 } from '@rainbow-me/rainbowkit/wallets';
 import { configureChains, createClient, WagmiConfig } from 'wagmi';
 import { mainnet, polygon, optimism, arbitrum, goerli } from 'wagmi/chains';
@@ -43,6 +44,7 @@
       argentWallet({ chains }),
       trustWallet({ chains }),
       ledgerWallet({ chains }),
+      exodusWallet({ chains }),
     ],
   },
 ]);
```
2. Run `yarn dev` in `./examples/with-next`
3. Make sure you can connect with Exodus: 
<img width="1397" alt="image" src="https://user-images.githubusercontent.com/8983736/233366802-53c90159-a82a-45bb-87bb-0230e7994b1c.png">
